### PR TITLE
Add ‘—legacy’, for compatability with Xcode 16

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,24 +8,8 @@ import {Formatter} from './formatter'
 import {Octokit} from '@octokit/action'
 import {glob} from 'glob'
 import {promises} from 'fs'
+import {getXcodeVersion} from './xcode'
 const {stat} = promises
-
-async function getXcodeVersion(): Promise<number> {
-  let output = '';
-  const options = {
-    listeners: {
-      stdout: (data: Buffer) => {
-        output += data.toString();
-      }
-    }
-  };
-  await exec.exec('xcodebuild', ['-version'], options);
-  const match = output.match(/Xcode (\d+)/);
-  if (match) {
-    return parseInt(match[1], 10);
-  }
-  throw new Error('Unable to determine Xcode version');
-}
 
 async function run(): Promise<void> {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,6 +160,7 @@ async function mergeResultBundle(
   const args = ['xcresulttool', 'merge']
     .concat(inputPaths)
     .concat(['--output-path', outputPath])
+	.concat(['--legacy'])
   const options = {
     silent: true
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,7 @@ async function mergeResultBundle(
   const args = ['xcresulttool', 'merge']
     .concat(inputPaths)
     .concat(['--output-path', outputPath])
-	.concat(['--legacy'])
+    .concat(['--legacy'])
   const options = {
     silent: true
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,7 @@ export class Parser {
       outputPath,
       '--id',
       reference,
-	  '--legacy'
+      '--legacy'
     ]
     const options = {
       silent: true
@@ -63,7 +63,7 @@ export class Parser {
       this.bundlePath,
       '--format',
       'json',
-	  '--legacy'
+      '--legacy'
     ]
     if (reference) {
       args.push('--id')

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,6 +2,8 @@
 
 import * as exec from '@actions/exec'
 import {promises} from 'fs'
+import {getXcodeVersion} from './xcode'
+
 const {readFile} = promises
 
 export class Parser {
@@ -17,6 +19,8 @@ export class Parser {
   }
 
   async exportObject(reference: string, outputPath: string): Promise<Buffer> {
+    const xcodeVersion = await getXcodeVersion();
+    
     const args = [
       'xcresulttool',
       'export',
@@ -27,9 +31,13 @@ export class Parser {
       '--output-path',
       outputPath,
       '--id',
-      reference,
-      '--legacy'
+      reference
     ]
+
+    if (xcodeVersion >= 16) {
+      args.push('--legacy');
+    }
+    
     const options = {
       silent: true
     }
@@ -56,20 +64,25 @@ export class Parser {
   }
 
   private async toJSON(reference?: string): Promise<string> {
+    const xcodeVersion = await getXcodeVersion();
+    
     const args = [
       'xcresulttool',
       'get',
       '--path',
       this.bundlePath,
       '--format',
-      'json',
-      '--legacy'
+      'json'
     ]
     if (reference) {
       args.push('--id')
       args.push(reference)
     }
 
+    if (xcodeVersion >= 16) {
+      args.push('--legacy');
+    }
+    
     let output = ''
     const options = {
       silent: true,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,7 +27,8 @@ export class Parser {
       '--output-path',
       outputPath,
       '--id',
-      reference
+      reference,
+	  '--legacy'
     ]
     const options = {
       silent: true
@@ -61,7 +62,8 @@ export class Parser {
       '--path',
       this.bundlePath,
       '--format',
-      'json'
+      'json',
+	  '--legacy'
     ]
     if (reference) {
       args.push('--id')

--- a/src/xcode.ts
+++ b/src/xcode.ts
@@ -1,0 +1,18 @@
+import * as exec from "@actions/exec";
+
+export async function getXcodeVersion(): Promise<number> {
+    let output = '';
+    const options = {
+        listeners: {
+            stdout: (data: Buffer) => {
+                output += data.toString();
+            }
+        }
+    };
+    await exec.exec('xcodebuild', ['-version'], options);
+    const match = output.match(/Xcode (\d+)/);
+    if (match) {
+        return parseInt(match[1], 10);
+    }
+    throw new Error('Unable to determine Xcode version');
+}


### PR DESCRIPTION
Some related discussion can be seen here - https://github.com/fastlane/fastlane/issues/22132

Originally opened at https://github.com/kishikawakatsumi/xcresulttool/pull/764 but it was suggested that this fork is better maintained (thank-you for that!). 